### PR TITLE
ci: Modify Dependabot settings for npm and schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,29 +1,13 @@
 version: 2
 updates:
-  # Enable version updates for npm
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
-    groups:
-      production-dependencies:
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
-      development-dependencies:
-        patterns:
-          - "@types/*"
-          - "eslint*"
-          - "typescript"
-        update-types:
-          - "minor"
-          - "patch"
-
-  # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    target-branch: "staging"
+
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+    target-branch: "staging"


### PR DESCRIPTION
Updated Dependabot configuration to enable npm updates and change schedule to daily.
 
 **PR Summary by Typo**
------------

#### Overview
This PR modifies Dependabot settings to streamline dependency updates, specifically for npm, and directs them to a staging branch with an increased frequency.

#### Key Changes
- Reordered Dependabot configurations, prioritizing GitHub Actions.
- Removed specific `open-pull-requests-limit` and `groups` for `npm` dependencies, simplifying its configuration.
- Configured Dependabot to target the `staging` branch for updates for both `github-actions` and `npm` package ecosystems.
- Changed the update schedule for `npm` dependencies from weekly to daily.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 1 (4.3%)      |
| Churn       | 17 (73.9%)    |
| Rework      | 5 (21.7%)     |
| Total Changes | 23            | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>