### PR TITLE
ci: Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
 name: Deploy
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/FalkorDB/support-portal/security/code-scanning/14](https://github.com/FalkorDB/support-portal/security/code-scanning/14)

In general, the fix is to explicitly declare `permissions` for the workflow or for each job, restricting `GITHUB_TOKEN` to the least privilege required. Since this workflow only checks out the repository and builds the project, it needs only read access to repository contents; there is no indication it needs to write to issues, pull requests, or packages.

The best minimal fix without changing functionality is to add a `permissions:` block at the top (root) workflow level, right under `name: Deploy`, setting `contents: read`. This will apply to all jobs (currently only `deploy`) that do not define their own `permissions:`. No other changes are needed: the `actions/checkout` and other steps will continue to work with `contents: read`, which is sufficient to clone the repository.

Concretely, in `.github/workflows/deploy.yml`, insert:

```yaml
permissions:
  contents: read
```

between line 1 (`name: Deploy`) and line 3 (`on:`). No imports or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
 
 **PR Summary by Typo**
------------

#### Overview
This PR addresses a code scanning alert by explicitly defining permissions for the `deploy.yml` workflow, ensuring it has read access to the repository contents.

#### Key Changes
- Added `permissions: contents: read` to the `deploy.yml` workflow configuration.

#### Work Breakdown

| Category | Lines Changed |
|----------|---------------|
| New Work | 2 (100.0%)    |
| Total Changes | 2         | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>