### PR TITLE
ci: Potential fix for code scanning alert no. 24: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, develop ]


### PR DESCRIPTION
Potential fix for [https://github.com/FalkorDB/support-portal/security/code-scanning/24](https://github.com/FalkorDB/support-portal/security/code-scanning/24)

In general, the fix is to explicitly declare a `permissions` block in the workflow so that the `GITHUB_TOKEN` has only the scopes required. For a pure CI job that just checks out code and runs local commands, `contents: read` is typically sufficient. You can set `permissions` at the workflow (top) level to apply to all jobs that don’t override it, or at the individual job level; here, setting it at the workflow level is simplest and preserves existing behavior while constraining the token.

The single best fix here is to add a root-level `permissions` block immediately after the `name: CI` line (and before `on:`) in `.github/workflows/ci.yml`. This will apply to `lint-and-build` and any other jobs in the file that don’t declare their own `permissions`. We will set `contents: read`, which is enough for `actions/checkout` and doesn’t introduce any new functionality, only restricts potential writes. No new imports or special methods are needed, just the YAML modification.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

 
 **PR Summary by Typo**
------------

#### Overview
This PR addresses a code scanning alert by explicitly defining permissions for the CI workflow, ensuring it has read access to repository contents.

#### Key Changes
- Added a `permissions` block to the `ci.yml` workflow, granting `contents: read` access.

#### Work Breakdown

| Category | Lines Changed |
|----------|---------------|
| New Work | 3 (100.0%)    |
| Total Changes | 3             | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>